### PR TITLE
fix(calendar): 최초 진입 시 ExpandableCalendar 렌더링 실패 수정

### DIFF
--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -6,13 +6,15 @@
  * - Month mode: Monthly grid view with item previews
  */
 
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useRef } from 'react';
+import { View, ActivityIndicator } from 'react-native';
 import { useFocusEffect } from 'expo-router';
 import { Header, SegmentedControl } from '@/components/common';
 import { AgendaCalendar } from '@/components/calendar/AgendaCalendar';
 import { MonthViewCalendar } from '@/components/calendar/MonthViewCalendar';
 import { TabScreenContent } from '@/design-system/layouts';
 import { useItemStore } from '@/store/itemStore';
+import { useThemeColor } from '@/design-system/hooks/useThemeColor';
 
 type ViewMode = 'agenda' | 'month';
 
@@ -21,11 +23,20 @@ export default function CalendarScreen() {
   const [selectedDate, setSelectedDate] = useState<string>(
     new Date().toISOString().split('T')[0]
   );
+  const [isReady, setIsReady] = useState(false);
+  const focusKeyRef = useRef(0);
+  const [focusKey, setFocusKey] = useState(0);
   const { items, loadItems } = useItemStore();
+  const spinnerColor = useThemeColor('#3B82F6', '#60A5FA');
 
   useFocusEffect(
     useCallback(() => {
-      loadItems();
+      focusKeyRef.current += 1;
+      const currentKey = focusKeyRef.current;
+      loadItems().then(() => {
+        setFocusKey(currentKey);
+        setIsReady(true);
+      });
     }, [loadItems])
   );
 
@@ -65,10 +76,15 @@ export default function CalendarScreen() {
         }
       />
       <TabScreenContent>
-        {viewMode === 'month' ? (
+        {!isReady ? (
+          <View className="flex-1 items-center justify-center">
+            <ActivityIndicator size="large" color={spinnerColor} />
+          </View>
+        ) : viewMode === 'month' ? (
           <MonthViewCalendar items={items} onDatePress={handleDatePress} />
         ) : (
           <AgendaCalendar
+            key={focusKey}
             selectedDate={selectedDate}
             onDateSelect={setSelectedDate}
             markedDates={markedDates}

--- a/components/calendar/AgendaCalendar.tsx
+++ b/components/calendar/AgendaCalendar.tsx
@@ -112,6 +112,7 @@ export function AgendaCalendar({ selectedDate, onDateSelect, markedDates, items 
       onDateChanged={onDateSelect}
     >
       <ExpandableCalendar
+        initialPosition={ExpandableCalendar.positions.CLOSED}
         theme={theme}
         firstDay={0} // 일요일 시작
         markedDates={finalMarkedDates}


### PR DESCRIPTION
최초 탭 진입 시 ExpandableCalendar가 렌더링되지 않는 현상 수정

## Root Cause
useFocusEffect에서 loadItems()가 비동기 실행되는 동안 달력이 먼저 렌더링되어 내부 height 계산 실패

## Changes
- app/(tabs)/calendar.tsx: isReady 상태 추가, focusKey로 탭 진입마다 강제 리마운트
- components/calendar/AgendaCalendar.tsx: initialPosition 명시적 지정

## Checklist
- [x] 최초 진입 시 달력 정상 렌더링
- [x] 두 번째 이후 진입도 정상 동작
- [x] 다크모드 정상 표시
- [x] markedDates 정상 표시


#3